### PR TITLE
Feat: User can input numbers with keypad

### DIFF
--- a/src/components/number-pad.tsx
+++ b/src/components/number-pad.tsx
@@ -6,9 +6,11 @@ import { Button, Grid } from "@mui/material";
 interface Props {
   input: number;
   setInput: (input: number) => void;
+  onReset: () => void;
+  onEnter: () => void;
 }
 
-const NumberPad: FC<Props> = ({ input, setInput }) => {
+const NumberPad: FC<Props> = ({ input, setInput, onEnter, onReset }) => {
   const buttons = [
     "1",
     "2",
@@ -19,15 +21,20 @@ const NumberPad: FC<Props> = ({ input, setInput }) => {
     "7",
     "8",
     "9",
-    "*",
+    "Reset",
     "0",
-    "Clear",
+    "Enter",
   ];
 
   const onClick = useCallback(
     (button: string) => {
       switch (button) {
-        case "Clear":
+        case "Reset":
+          onReset();
+          setInput(0);
+          break;
+        case "Enter":
+          onEnter();
           setInput(0);
           break;
         case "*":
@@ -44,12 +51,7 @@ const NumberPad: FC<Props> = ({ input, setInput }) => {
     <Grid container spacing={1} style={{ maxWidth: "200px" }}>
       {buttons.map((button) => (
         <Grid item xs={4} key={button}>
-          <Button
-            variant="contained"
-            fullWidth
-            onClick={() => onClick(button)}
-            disabled={button === "*"}
-          >
+          <Button variant="contained" fullWidth onClick={() => onClick(button)}>
             {button}
           </Button>
         </Grid>

--- a/src/components/number-pad.tsx
+++ b/src/components/number-pad.tsx
@@ -10,22 +10,22 @@ interface Props {
   onEnter: () => void;
 }
 
-const NumberPad: FC<Props> = ({ input, setInput, onEnter, onReset }) => {
-  const buttons = [
-    "1",
-    "2",
-    "3",
-    "4",
-    "5",
-    "6",
-    "7",
-    "8",
-    "9",
-    "Reset",
-    "0",
-    "Enter",
-  ];
+const buttons = [
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "Reset",
+  "0",
+  "Enter",
+];
 
+const NumberPad: FC<Props> = ({ input, setInput, onEnter, onReset }) => {
   const onClick = useCallback(
     (button: string) => {
       switch (button) {
@@ -44,7 +44,7 @@ const NumberPad: FC<Props> = ({ input, setInput, onEnter, onReset }) => {
           setInput(input * 10 + parseInt(button));
       }
     },
-    [input, setInput],
+    [input, setInput, onReset, onEnter],
   );
 
   return (

--- a/src/components/organism_dist_buttons_chunk/index.tsx
+++ b/src/components/organism_dist_buttons_chunk/index.tsx
@@ -4,6 +4,34 @@ import { Box, Stack, Typography } from "@mui/material";
 import { FC, Fragment, useCallback, useEffect, useState } from "react";
 import NumberPad from "../number-pad";
 
+type Key =
+  | "swings"
+  | "teeHeight"
+  | "swingType"
+  | "ballAim"
+  | "stability"
+  | "carry"
+  | "distance"
+  | "ballSpeed"
+  | "launchAngle"
+  | "apex"
+  | "hangTime"
+  | "landingAngle"
+  | "curve"
+  | "offCenter";
+
+type Value =
+  | "string"
+  | "number:0:90"
+  | "number:0:999"
+  | "center"
+  | "left"
+  | "right"
+  | "front"
+  | "back"
+  | "inside"
+  | "outside";
+
 interface NumberValue {
   value: number
   from: number

--- a/src/components/organism_dist_buttons_chunk/index.tsx
+++ b/src/components/organism_dist_buttons_chunk/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Stack, Typography } from "@mui/material";
-import { FC, useCallback,useState } from "react";
+import { FC, useCallback, useState } from "react";
 import NumberPad from "../number-pad";
 
 type Key =
@@ -109,21 +109,28 @@ const DistButtonChunk: FC = () => {
     });
 
     const nextKeyIndex = keyIndex + 1;
-    if (maxKeyIndex < nextKeyIndex) onReset()
+    if (maxKeyIndex < nextKeyIndex) onReset();
     else setIndex(keyIndex + 1);
   }, [keyNow, keyIndex, input, onReset]);
 
   return (
     <Stack alignItems={"center"} p={2}>
-      <Typography>{keyNow + "?: " + input}</Typography>
+      <Typography color="red">{keyNow + "?: " + input}</Typography>
       {/* Show Props */}
       <Stack direction={"row"} spacing={2} p={1}>
-        {keys.map((key) => (
-          <Typography key={key}>{key + `: ${swingProp[key]}`}</Typography>
+        {keys.map((key, i) => (
+          <Typography color={keyIndex === i ? "red" : undefined} key={key}>
+            {key + `: ${swingProp[key]}`}
+          </Typography>
         ))}
       </Stack>
       <Box p={1} />
-      <NumberPad input={input} setInput={setInput} onEnter={onEnter} onReset={onReset}/>
+      <NumberPad
+        input={input}
+        setInput={setInput}
+        onEnter={onEnter}
+        onReset={onReset}
+      />
     </Stack>
   );
 };

--- a/src/components/organism_dist_buttons_chunk/index.tsx
+++ b/src/components/organism_dist_buttons_chunk/index.tsx
@@ -1,7 +1,5 @@
-import { getSwingsApi, ISwing } from "@/api/swings/get-swings.api";
-import StyledTextButtonAtom from "@/atoms/StyledTextButton";
 import { Box, Stack, Typography } from "@mui/material";
-import { FC, Fragment, useCallback, useEffect, useState } from "react";
+import { FC, useCallback,useState } from "react";
 import NumberPad from "../number-pad";
 
 type Key =
@@ -33,16 +31,16 @@ type Value =
   | "outside";
 
 interface NumberValue {
-  value: number
-  from: number
-  until: number
+  value: number;
+  from: number;
+  until: number;
 }
 
-interface Props {
+interface SwingProps {
   swings: number;
   teeHeight: number;
   swingType: number;
-  ballAim: "center" | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+  ballAim: number; // TODO: For now
   stability: number;
   carry: number;
   distance: number;
@@ -55,11 +53,11 @@ interface Props {
   offCenter: number;
 }
 
-const myDefault: Props = {
+const myDefault: SwingProps = {
   swings: 0,
   teeHeight: 0,
   swingType: 0,
-  ballAim: "center",
+  ballAim: 0,
   stability: 0,
   carry: 0,
   distance: 0,
@@ -70,74 +68,62 @@ const myDefault: Props = {
   landingAngle: 0,
   curve: 0,
   offCenter: 0,
-}
-
-const findClosestKeys = (map: Map<number, ISwing>, input: number): ISwing[] => {
-  const sortedKeys = Array.from(map.keys()).sort((a, b) => a - b);
-
-  let closestKeys = [];
-  let lowerBound = input;
-  let upperBound = input;
-
-  while (closestKeys.length < 2) {
-    if (sortedKeys.includes(lowerBound)) closestKeys.push(lowerBound);
-    if (sortedKeys.includes(upperBound) && lowerBound !== upperBound)
-      closestKeys.push(upperBound);
-
-    lowerBound--;
-    upperBound++;
-  }
-
-  return closestKeys.map((key) => map.get(key)!);
 };
 
-const DistButtonChunk: FC = () => {
-  const [data, setData] = useState<Map<number, ISwing> | null>(null);
-  const [input, setInput] = useState<number>(0);
-  const [selectedSwings, selectSwings] = useState<ISwing[]>([]);
+const keys: Key[] = [
+  "swings",
+  "teeHeight",
+  "swingType",
+  "ballAim",
+  "stability",
+  "carry",
+  "distance",
+  "ballSpeed",
+  "launchAngle",
+  "apex",
+  "hangTime",
+  "landingAngle",
+  "curve",
+  "offCenter",
+];
+const maxKeyIndex = keys.length - 1;
 
-  useEffect(() => {
-    const result = getSwingsApi();
-    const map = new Map<number, ISwing>();
-    result.swings.forEach((swing) => {
-      map.set(swing.total, swing);
-    });
-    setData(map);
+const DistButtonChunk: FC = () => {
+  const [swingProp, setSwingProp] = useState<SwingProps>(myDefault);
+  const [keyIndex, setIndex] = useState<number>(0);
+  const [input, setInput] = useState<number>(0);
+
+  const keyNow = keys[keyIndex];
+
+  const onReset = useCallback(() => {
+    setInput(0);
+    setIndex(0);
+    setSwingProp(myDefault);
   }, []);
 
-  useEffect(() => {
-    if (input === 0) return selectSwings([]);
-    if (data === null) return;
+  const onEnter = useCallback(() => {
+    setSwingProp((prev) => {
+      const newValue = { ...prev };
+      newValue[keyNow] = input;
+      return newValue;
+    });
 
-    // find two closest with the data:
-    selectSwings(findClosestKeys(data, input));
-  }, [data, input]);
+    const nextKeyIndex = keyIndex + 1;
+    if (maxKeyIndex < nextKeyIndex) onReset()
+    else setIndex(keyIndex + 1);
+  }, [keyNow, keyIndex, input, onReset]);
 
   return (
     <Stack alignItems={"center"} p={2}>
-      {input}
+      <Typography>{keyNow + "?: " + input}</Typography>
+      {/* Show Props */}
+      <Stack direction={"row"} spacing={2} p={1}>
+        {keys.map((key) => (
+          <Typography key={key}>{key + `: ${swingProp[key]}`}</Typography>
+        ))}
+      </Stack>
       <Box p={1} />
-      <NumberPad input={input} setInput={setInput} />
-      {selectedSwings.map((swing) => (
-        <Fragment
-          key={swing.club + swing.grip + swing.stanceDistance + swing.swingType}
-        >
-          <Typography>
-            {"Club: "}
-            <b>{swing.club}</b>
-            {" Grip: "}
-            <b>{swing.grip}</b>
-            {" Stance: "}
-            <b>{swing.stanceDistance}</b>
-            {" Carry (Distance): "}
-            <b>
-              {swing.carry + " "} {"(" + swing.total + ")"} {}
-            </b>
-            {" Missing: "}
-            <b>{input - swing.total}</b>
-          </Typography>
-        </Fragment>
-      ))}
+      <NumberPad input={input} setInput={setInput} onEnter={onEnter} onReset={onReset}/>
     </Stack>
   );
 };

--- a/src/components/organism_dist_buttons_chunk/index.tsx
+++ b/src/components/organism_dist_buttons_chunk/index.tsx
@@ -4,6 +4,46 @@ import { Box, Stack, Typography } from "@mui/material";
 import { FC, Fragment, useCallback, useEffect, useState } from "react";
 import NumberPad from "../number-pad";
 
+interface NumberValue {
+  value: number
+  from: number
+  until: number
+}
+
+interface Props {
+  swings: number;
+  teeHeight: number;
+  swingType: number;
+  ballAim: "center" | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+  stability: number;
+  carry: number;
+  distance: number;
+  ballSpeed: number;
+  launchAngle: number;
+  apex: number;
+  hangTime: number;
+  landingAngle: number;
+  curve: number;
+  offCenter: number;
+}
+
+const myDefault: Props = {
+  swings: 0,
+  teeHeight: 0,
+  swingType: 0,
+  ballAim: "center",
+  stability: 0,
+  carry: 0,
+  distance: 0,
+  ballSpeed: 0,
+  launchAngle: 0,
+  apex: 0,
+  hangTime: 0,
+  landingAngle: 0,
+  curve: 0,
+  offCenter: 0,
+}
+
 const findClosestKeys = (map: Map<number, ISwing>, input: number): ISwing[] => {
   const sortedKeys = Array.from(map.keys()).sort((a, b) => a - b);
 


### PR DESCRIPTION
# Background
We first want to make a simple demo input.

## What's done?
Created a keypad with input:
![image](https://github.com/user-attachments/assets/5128c1e2-906c-4c7d-ae27-4cab1aedb52c)

With the red colored, it is well focused:
![image](https://github.com/user-attachments/assets/4c744faf-aa85-455c-8d0c-b83cb75a0cd8)



## What are the related PRs?
None

## What's next?
Will implement dropdowns

## Checklist Before PR Review
- [x] The following has been handled:
  - `Title` is checked
  - `Background` is filled
  - `What's done?` is filled
  - `What are the related PRs?` is filled
  - `What's next?` is filled
  - `Draft` is set for this PR
  - `Assignee` is set
  - `Labels` are set
  - `Development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done, if frontend related
  - Make this PR as an open PR
  - Double-check `What's done?` matches to the actual changes
  - Appropriate ajktown/docs sync pr done if needed

## Checklist (Reviewers)
- [x] Review if the following has been handled:
  - Review Code
  - `Checklist Before PR Review` is correctly handled
  - `Checklist (Right Before PR Review Request)` is correctly handled
  - Check if there are any other missing TODOs (Checklists) that are not yet listed
  - Check if issue under `Development` is fully handled if exists
  - Check if appropriate issues are created from `What's next?`


